### PR TITLE
Compiler optimization level 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livelyvideo/mediasoup",
-  "version": "3.6.0-disable-origin-check",
+  "version": "3.6.0-optimizationO3",
   "description": "Cutting Edge WebRTC Video Conferencing",
   "contributors": [
     "Iñaki Baz Castillo <ibc@aliax.net> (https://inakibaz.me)",

--- a/worker/common.gypi
+++ b/worker/common.gypi
@@ -23,7 +23,7 @@
     {
       'Release':
       {
-        'cflags': [ '-g', '-Wno-unknown-warning-option', '-fPIC' ]
+        'cflags': [ '-g', '-O3', '-Wno-unknown-warning-option', '-fPIC' ]
       },
       'Debug':
       {

--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -257,6 +257,7 @@
       }],
 
       [ 'OS == "linux"', {
+        'cflags': [ '-O3' ],
         'defines':
         [
           '_POSIX_C_SOURCE=200112',
@@ -265,7 +266,7 @@
       }],
 
       [ 'OS == "linux" and mediasoup_asan == "true"', {
-        'cflags': [ '-fsanitize=address' ],
+        'cflags': [ '-fsanitize=address', '-O3' ],
         'ldflags': [ '-fsanitize=address' ]
       }],
 


### PR DESCRIPTION
Compile msworker with gcc compliation optimization level 3. This gives noticeable CPU% gain - 1.5 times better "total CPU per SFU call" and similar "total CPU usage per SFU peer".