### PR TITLE
Ability to build a non-transcode pure mediasoup-worker

### DIFF
--- a/lib/Worker.js
+++ b/lib/Worker.js
@@ -67,7 +67,7 @@ class Worker extends EnhancedEventEmitter_1.EnhancedEventEmitter {
         // options
         {
             env: {
-                MEDIASOUP_VERSION: '3.6.21-shm'
+                MEDIASOUP_VERSION: '3.6.21-shm2'
             },
             detached: false,
             // fd 0 (stdin)   : Just ignore it.

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ exports.types = types;
 /**
  * Expose mediasoup version.
  */
-exports.version = '3.6.21-shm';
+exports.version = '3.6.21-shm2';
 /**
  * Expose parseScalabilityMode() function.
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livelyvideo/mediasoup",
-  "version": "3.6.21-shm",
+  "version": "3.6.21-shm2",
   "description": "Cutting Edge WebRTC Video Conferencing",
   "contributors": [
     "Iñaki Baz Castillo <ibc@aliax.net> (https://inakibaz.me)",

--- a/worker/include/RTC/ShmTransport.hpp
+++ b/worker/include/RTC/ShmTransport.hpp
@@ -30,6 +30,7 @@ namespace RTC
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) override;
 		void HandleRequest(Channel::Request* request) override;
+		void HandleNotification(PayloadChannel::Notification* notification) override;
 		bool RecvStreamMeta(json& data) override;
 		DepLibSfuShm::ShmCtx* ShmCtx() { return &this->shmCtx; }
 

--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -326,8 +326,15 @@
   'targets':
   [
     {
+      # This configuration builds mediasoup-worker with transcode functionality and need ngxshm libs to link to.
+      # How to build plain mediasoup without transcode shm dependencies:
+      #  - remove TRANSCODE from 'defines'[] array,
+      #  - comment out all C++ source and include files but src/main.cpp,
+      #  - comment out '-lffngxshm' and '-lngxshm' from 'link_settings'[] array
+      #  - make as usually
+      #  - publish: update package.json with a distinct version name (x.x.x-noshm), run 'npm run typescript:build' and 'npm publish'
       'target_name': 'mediasoup-worker',
-      'defines': [ 'FFNGXSHM_MAX_NUM_CHANNELS=10', 'SFUSHM_AV_MAX_NUM_CHANNELS=10', 'STREAM_SHM_MAX_CHANNELS=10' ],
+      'defines': [ 'TRANSCODE', 'FFNGXSHM_MAX_NUM_CHANNELS=10', 'SFUSHM_AV_MAX_NUM_CHANNELS=10', 'STREAM_SHM_MAX_CHANNELS=10' ],
       'sources': [
         # C++ source files.
         'src/main.cpp',

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -10,7 +10,9 @@
 #include "RTC/PipeTransport.hpp"
 #include "RTC/PlainTransport.hpp"
 #include "RTC/WebRtcTransport.hpp"
+#ifdef TRANSCODE
 #include "RTC/ShmTransport.hpp"
+#endif
 
 namespace RTC
 {
@@ -250,6 +252,7 @@ namespace RTC
 
 			case Channel::Request::MethodId::ROUTER_CREATE_SHM_TRANSPORT:
 			{
+#ifdef TRANSCODE
 				std::string transportId;
 
 				// This may throw
@@ -267,7 +270,7 @@ namespace RTC
 				shmTransport->FillJson(data);
 
 				request->Accept(data);
-
+#endif
 				break;
 			}
 			case Channel::Request::MethodId::ROUTER_CREATE_DIRECT_TRANSPORT:

--- a/worker/src/RTC/ShmTransport.cpp
+++ b/worker/src/RTC/ShmTransport.cpp
@@ -309,6 +309,15 @@ namespace RTC
 	}
 
 
+	void ShmTransport::HandleNotification(PayloadChannel::Notification* notification)
+	{
+		MS_TRACE();
+
+		// Pass it to the parent class.
+		RTC::Transport::HandleNotification(notification);
+	}
+
+
 	inline bool ShmTransport::IsConnected() const
 	{
 		return true;

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -20,8 +20,10 @@
 #include "RTC/SimpleConsumer.hpp"
 #include "RTC/SimulcastConsumer.hpp"
 #include "RTC/SvcConsumer.hpp"
+#ifdef TRANSCODE
 #include "RTC/ShmTransport.hpp"
 #include "RTC/ShmConsumer.hpp"
+#endif
 #include <libwebrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.h> // webrtc::RtpPacketSendInfo
 #include <iterator>                                              // std::ostream_iterator
 #include <map>                                                   // std::multimap
@@ -833,13 +835,13 @@ namespace RTC
 
 						break;
 					}
-
 					case RTC::RtpParameters::Type::SHM:
 					{
+#ifdef TRANSCODE
 						// This may throw.
 						MS_DEBUG_TAG(rtp, "ShmConsumer will be created with data [%s]", request->data.dump().c_str());
 						consumer = new RTC::ShmConsumer(consumerId, producerId, this, request->data, dynamic_cast<RTC::ShmTransport*>(this)->ShmCtx());
-
+#endif
 						break;
 					}
 				}
@@ -1232,10 +1234,12 @@ namespace RTC
 
 			case Channel::Request::MethodId::TRANSPORT_CONSUME_STREAM_META:
 			{
+#ifdef TRANSCODE
 				if (RecvStreamMeta(request->data))
 					request->Accept();
 				else
 					request->Error("ShmTransport::RecvStreamMeta returned false");
+#endif
 				break;
 			}
 				
@@ -2174,8 +2178,6 @@ namespace RTC
 					}
 
 					producer->ReceiveRtcpSenderReport(report);
-
-					// TODO: if this is shmTransport, then can write RTCP SR data into shm in some suitable format, since it was already parsed.
 				}
 
 				break;


### PR DESCRIPTION
Use TRANSCODE flag and instructions in mediasoup-worker.gyp to build mediasoup without transcode shm functionality