### PR TITLE
VIDEO-283 producerStats is missing width/height in Mediasoup v.3.19.7-lv3-notranscode

### DIFF
--- a/Dockerfile.mediasoup
+++ b/Dockerfile.mediasoup
@@ -65,7 +65,7 @@ ENV MEDIASOUP_BUILDTYPE=${MEDIASOUP_BUILDTYPE_ARG}
 ENV MESON_ARGS="-Dms_disable_liburing=true"
 
 # Force cache invalidation: increment this number to force npm rebuild execution
-ARG CACHE_BUST=3.19.7-lv3-1
+ARG CACHE_BUST=3.19.7-TD-2988-1
 
 RUN \
   cd ${MS_BUILD} && \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livelyvideo/mediasoup",
-  "version": "3.19.7-lv3-notranscode",
+  "version": "3.19.7-TD29881-notranscode",
   "description": "Cutting Edge WebRTC Video Conferencing",
   "contributors": [
     "Iñaki Baz Castillo <ibc@aliax.net> (https://inakibaz.me)",

--- a/worker/src/RTC/Codecs/H264.cpp
+++ b/worker/src/RTC/Codecs/H264.cpp
@@ -9,6 +9,277 @@ namespace RTC
 {
 	namespace Codecs
 	{
+	/**********************************************************************
+	 *                Added by Amir Pauker 02/27/2024 RND-568
+	 * this code is based on ngx_rtmp_bitop.c and ngx_rtmp_codec_module.c
+	 *********************************************************************/
+
+	uint64_t H264SPSParser::Read(uint64_t n)
+	{
+	    uint64_t    v;
+	    uint64_t    d;
+
+	    v = 0;
+
+	    while (n) {
+	        if (this->pos >= this->last) {
+	            this->err = 1;
+	            return 0;
+	        }
+
+	        d = (this->offs + n > 8 ? (uint64_t) (8 - this->offs) : n);
+
+	        v <<= d;
+	        v += (*this->pos >> (8 - this->offs - d)) & ((u_char) 0xff >> (8 - d));
+
+	        this->offs += d;
+	        n -= d;
+
+	        if (this->offs == 8) {
+	            this->pos++;
+	            this->offs = 0;
+	        }
+	    }
+
+	    return v;
+	}
+
+
+	uint64_t H264SPSParser::ReadGolomb()
+	{
+	    uint64_t  n;
+
+	    for (n = 0; Read(1) == 0 && !err; n++);
+
+	    return ((uint64_t) 1 << n) + Read(n) - 1;
+	}
+
+
+	void H264SPSParser::ParseSPS(uint16_t &widthOut, uint16_t &heightOut)
+	{
+	    uint64_t   profile_idc, width, height, crop_left, crop_right,
+	               crop_top, crop_bottom, frame_mbs_only, n, cf_idc,
+	               num_ref_frames;
+
+	    // profile idc
+	    profile_idc = (uint64_t) Read(8);
+
+	    // flags
+	    Read(8);
+
+	    // level idc
+	    Read(8);
+
+	    /* SPS id */
+	    ReadGolomb();
+
+	    if (profile_idc == 100 || profile_idc == 110 ||
+	        profile_idc == 122 || profile_idc == 244 || profile_idc == 44 ||
+	        profile_idc == 83 || profile_idc == 86 || profile_idc == 118)
+	    {
+	        /* chroma format idc */
+	        cf_idc = ReadGolomb();
+
+	        if (cf_idc == 3) {
+
+	            /* separate color plane */
+	            Read(1);
+	        }
+
+	        /* bit depth luma - 8 */
+	        ReadGolomb();
+
+	        /* bit depth chroma - 8 */
+	        ReadGolomb();
+
+	        /* qpprime y zero transform bypass */
+	        Read(1);
+
+	        /* seq scaling matrix present */
+	        if (Read(1)) {
+
+	            for (n = 0; n < (cf_idc != 3 ? 8u : 12u); n++) {
+
+	                /* seq scaling list present */
+	                if (Read(1)) {
+
+	                    /* TODO: scaling_list()
+	                    if (n < 6) {
+	                    } else {
+	                    }
+	                    */
+	                }
+	            }
+	        }
+	    }
+
+	    /* log2 max frame num */
+	    ReadGolomb();
+
+	    /* pic order cnt type */
+	    switch (ReadGolomb()) {
+	    case 0:
+
+	        /* max pic order cnt */
+	        ReadGolomb();
+	        break;
+
+	    case 1:
+
+	        /* delta pic order alwys zero */
+	        Read(1);
+
+	        /* offset for non-ref pic */
+	        ReadGolomb();
+
+	        /* offset for top to bottom field */
+	        ReadGolomb();
+
+	        /* num ref frames in pic order */
+	        num_ref_frames = ReadGolomb();
+
+	        for (n = 0; n < num_ref_frames; n++) {
+
+	            /* offset for ref frame */
+	            ReadGolomb();
+	        }
+	    }
+
+	    /* num ref frames */
+	    ReadGolomb();
+
+	    /* gaps in frame num allowed */
+	    Read(1);
+
+	    /* pic width in mbs - 1 */
+	    width = ReadGolomb();
+
+	    /* pic height in map units - 1 */
+	    height = ReadGolomb();
+
+	    /* frame mbs only flag */
+	    frame_mbs_only = Read(1);
+
+	    if (!frame_mbs_only) {
+
+	        /* mbs adaprive frame field */
+	        Read(1);
+	    }
+
+	    /* direct 8x8 inference flag */
+	    Read(1);
+
+	    /* frame cropping */
+	    if (Read(1)) {
+
+	        crop_left   = ReadGolomb();
+	        crop_right  = ReadGolomb();
+	        crop_top    = ReadGolomb();
+	        crop_bottom = ReadGolomb();
+
+	    } else {
+
+	        crop_left = 0;
+	        crop_right = 0;
+	        crop_top = 0;
+	        crop_bottom = 0;
+	    }
+
+	    if (!err) {
+	        widthOut = (width + 1) * 16 - (crop_left + crop_right) * 2;
+	        heightOut = (2 - frame_mbs_only) * (height + 1) * 16 -
+	                      (crop_top + crop_bottom) * 2;
+	    }
+	}
+
+	/**********************************************************************
+	 *                Added by Amir Pauker 02/27/2024 RND-568
+	 *  Re-grafted onto the 3.19.7 upstream structure (TD-2988).
+	 *
+	 *  Upstream split key-frame detection into H264::IsKeyFrame(); this is
+	 *  the parallel pass that extracts video resolution from the SPS NAL.
+	 *  The DependencyDescriptor never carries width/height, so — exactly as
+	 *  v3-lively forced with `if (true)` — this runs on every packet and
+	 *  only the SPS (type 7) NAL actually triggers a parse.
+	 *********************************************************************/
+	static void ParseH264Resolution(const uint8_t* data, size_t len, H264::PayloadDescriptor* payloadDescriptor)
+	{
+		if (len < 2)
+		{
+			return;
+		}
+
+		const uint8_t nal = *data & 0x1F;
+
+		switch (nal)
+		{
+			// Single NAL unit packet.
+			// IDR (instantaneous decoding picture).
+			case 7:
+			{
+				H264SPSParser spsParser(data + 1, data + len);
+				spsParser.ParseSPS(payloadDescriptor->width, payloadDescriptor->height);
+
+				break;
+			}
+
+			// Aggreation packet.
+			// STAP-A.
+			case 24:
+			{
+				size_t offset{ 1 };
+
+				len -= 1;
+
+				// Iterate NAL units.
+				while (len >= 3)
+				{
+					auto naluSize        = Utils::Byte::Get2Bytes(data, offset);
+					const uint8_t subnal = *(data + offset + sizeof(naluSize)) & 0x1F;
+
+					if (subnal == 7)
+					{
+						H264SPSParser spsParser((data + offset + sizeof(naluSize)) + 1, (data + offset + sizeof(naluSize)) + len);
+						spsParser.ParseSPS(payloadDescriptor->width, payloadDescriptor->height);
+
+						break;
+					}
+
+					// Check if there is room for the indicated NAL unit size.
+					if (len < (naluSize + sizeof(naluSize)))
+					{
+						break;
+					}
+
+					offset += naluSize + sizeof(naluSize);
+					len -= naluSize + sizeof(naluSize);
+				}
+
+				break;
+			}
+
+			// Aggreation packet.
+			// FU-A, FU-B.
+			case 28:
+			case 29:
+			{
+				const uint8_t subnal   = *(data + 1) & 0x1F;
+				const uint8_t startBit = *(data + 1) & 0x80;
+
+				if (subnal == 7 && startBit == 128)
+				{
+					H264SPSParser spsParser(data + 1, data + len);
+					spsParser.ParseSPS(payloadDescriptor->width, payloadDescriptor->height);
+				}
+
+				break;
+			}
+		}
+	}
+
+	/**********************************************************************
+        **********************************************************************/
+
 		/* Class methods. */
 
 		H264::PayloadDescriptor* H264::Parse(
@@ -32,6 +303,11 @@ namespace RTC
 			{
 				payloadDescriptor->isKeyFrame = IsKeyFrame(data, len);
 			}
+
+			// Added by Amir Pauker 02/27/2024 RND-568 — re-grafted (TD-2988).
+			// Always parse the SPS for resolution; the DependencyDescriptor
+			// never carries width/height. Replicates v3-lively's `if (true)`.
+			ParseH264Resolution(data, len, payloadDescriptor.get());
 
 			return payloadDescriptor.release();
 		}


### PR DESCRIPTION
Restored missing source code dropped accidentally during upstream pull from versatica. There need to be additional minor commit to use correct version# straight into v3-lively branch, followed by SFU build from main.